### PR TITLE
Fixed CsvToDataTable issue to remove the outer quotes from the first field of each row

### DIFF
--- a/FileHelpers.Tests/FileHelpers.Tests.csproj
+++ b/FileHelpers.Tests/FileHelpers.Tests.csproj
@@ -581,6 +581,7 @@
     <Content Include="Data\Good\ReadAsDataTable.txt" />
     <Content Include="Data\Good\RealCsvComma1.txt" />
     <Content Include="Data\Good\RealCsvComma2.txt" />
+    <Content Include="Data\Good\RealCsvQuoteRemoval.txt" />
     <Content Include="Data\Good\RealCsvTab1.txt" />
     <Content Include="Data\Good\RealCsvTab2.txt" />
     <Content Include="Data\Good\RealCsvVerticalBar1.txt" />

--- a/FileHelpers.Tests/Tests/Common/CsvEngineTests.cs
+++ b/FileHelpers.Tests/Tests/Common/CsvEngineTests.cs
@@ -170,5 +170,21 @@ namespace FileHelpers.Tests.CommonTests
 
 		}
 
+        [Test]
+        public void TestRemoveQuotesFirstCellOfRow()
+        {
+            string file = TestCommon.GetPath("Good", "RealCsvQuoteRemoval.txt");
+            string classname = "CustomerComma";
+            char delimiter = ',';
+
+            DataTable dt = CsvEngine.CsvToDataTable(file, classname, delimiter, true, true);
+            Assert.AreEqual(2, dt.Rows.Count);
+
+            string firstColumn = dt.Rows[0].ItemArray[0].ToString();
+
+            Assert.AreEqual("NormalizeAddress", dt.Columns[0].ColumnName);
+            Assert.AreEqual("Y", firstColumn);
+        }
+
 	}
 }

--- a/FileHelpers/Core/RecordOperations.cs
+++ b/FileHelpers/Core/RecordOperations.cs
@@ -88,6 +88,7 @@ namespace FileHelpers
 
             for (int i = 0; i < RecordInfo.FieldCount; i++)
             {
+                
                 values[i] = RecordInfo.Fields[i].ExtractFieldValue(line);
             }
 

--- a/FileHelpers/Fields/FieldBase.cs
+++ b/FileHelpers/Fields/FieldBase.cs
@@ -624,20 +624,30 @@ namespace FileHelpers
             switch (TrimMode)
             {
                 case TrimMode.None:
-                    return extractedString;
+                    return RemoveOuterQuotes(extractedString);
 
                 case TrimMode.Both:
-                    return extractedString.Trim();
+                    return RemoveOuterQuotes(extractedString.Trim());
 
                 case TrimMode.Left:
-                    return extractedString.TrimStart();
+                    return RemoveOuterQuotes(extractedString.TrimStart());
 
                 case TrimMode.Right:
-                    return extractedString.TrimEnd();
+                    return RemoveOuterQuotes(extractedString.TrimEnd());
 
                 default:
                     throw new Exception("Trim mode invalid in FieldBase.TrimString -> " + TrimMode.ToString());
             }
+        }
+
+        /// <summary>
+        /// Removes the outer double quotes from a string when it is being extracted from a file.
+        /// </summary>
+        /// <param name="extractedString"></param>
+        /// <returns></returns>
+        private String RemoveOuterQuotes(string extractedString)
+        {
+            return extractedString.TrimStart('"').TrimEnd('"');
         }
 
         /// <summary>

--- a/FileHelpers/FileHelpers.xml
+++ b/FileHelpers/FileHelpers.xml
@@ -8544,6 +8544,13 @@
             <param name="line">Underlying input data</param>
             <returns>Object to assign to field</returns>
         </member>
+        <member name="M:FileHelpers.FieldBase.RemoveOuterQuotes(System.String)">
+            <summary>
+            Removes the outer double quotes from a string when it is being extracted from a file.
+            </summary>
+            <param name="extractedString"></param>
+            <returns></returns>
+        </member>
         <member name="M:FileHelpers.FieldBase.GetNullValue(FileHelpers.LineInfo)">
             <summary>
             Convert a null value into a representation,


### PR DESCRIPTION
When importing a csv file through the CsvToDataTable option it would leave the double outer quotes around the first field of each row.  A fix was added to remove the double outer quotes when it is breaking apart each string of the line.  Any inner double quotes are left alone.