### PR TITLE
Add to ErrorManager an recording limit

### DIFF
--- a/FileHelpers/ErrorHandling/ErrorManager.cs
+++ b/FileHelpers/ErrorHandling/ErrorManager.cs
@@ -15,6 +15,9 @@ namespace FileHelpers
     public sealed class ErrorManager
         :IEnumerable
 	{
+
+        private int mErrorLimit = 10000;
+
 		/// <summary>
         /// Initializes a new instance of the <see cref="ErrorManager"/> class.
         /// </summary>
@@ -32,6 +35,13 @@ namespace FileHelpers
 			mErrorMode = mode;
 		}
 
+        /// <summary>Maximum number of recorded errors. After this limit is reached, successive errors are ignored.</summary>
+        /// <remarks>Default error limit is 10000.</remarks>
+        public int ErrorLimit
+        {
+            get { return mErrorLimit; }
+            set { mErrorLimit = value; }
+        }
 
         private string ErrorsDescription()
         {
@@ -44,7 +54,7 @@ namespace FileHelpers
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        readonly ArrayList mErrorsArray = new ArrayList();
+        List<ErrorInfo> mErrorsArray = new List<ErrorInfo> ();
 
 		/// <summary>
         /// Is an array of <see cref="ErrorInfo"/> that contains the
@@ -53,7 +63,7 @@ namespace FileHelpers
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public ErrorInfo[] Errors
 		{
-			get { return (ErrorInfo[]) mErrorsArray.ToArray(typeof (ErrorInfo)); }
+            get { return mErrorsArray.ToArray (); }
 		}
 
 
@@ -65,7 +75,8 @@ namespace FileHelpers
         /// Indicates the behavior of the <see cref="FileHelperEngine"/>
         /// when it found an error.
         /// </summary>
-		public ErrorMode ErrorMode
+        /// <remarks>Default error mode is ThrowException.</remarks>
+        public ErrorMode ErrorMode
 		{
 			get { return mErrorMode; }
 			set { mErrorMode = value; }
@@ -94,13 +105,15 @@ namespace FileHelpers
 		/// <param name="error"></param>
 		internal void AddError(ErrorInfo error)
 		{
-			mErrorsArray.Add(error);
+            if (mErrorsArray.Count <= mErrorLimit)
+			    mErrorsArray.Add(error);
 		}
 
 		/// <summary>Add the specified ErrorInfo to the contained collection.</summary>
 		internal void AddErrors(ErrorManager errors)
 		{
-			mErrorsArray.AddRange(errors.mErrorsArray);
+            if (mErrorsArray.Count <= mErrorLimit)
+			    mErrorsArray.AddRange(errors.mErrorsArray);
 		}
 
 //		public void ProcessError(Exception ex, string line)


### PR DESCRIPTION
This modification allows easier time when dealing with very large files. Sometimes when there is a layout mismatch in a large file we could get an out-of-memory exception or simply have to wait for the entire file to finish being parsed to notice that the entire processing was for nothing... 
1. Add to ErrorManager an recording limit to avoid possible out-of-memory errors in case of layout errors when dealing with large files. After the threshold is reached, successive errors are ignored.
2. Also updated the ErrorManager data structure to List<ErrorInfo>.
