### PR TITLE
Enable AutoFlush FileHelperAsyncEngine write mode

### DIFF
--- a/FileHelpers/Engines/FileHelperAsyncEngine.cs
+++ b/FileHelpers/Engines/FileHelperAsyncEngine.cs
@@ -519,9 +519,9 @@ namespace FileHelpers
         /// <param name="bufferSize">Size of the write buffer</param>
         public IDisposable BeginWriteFile(string fileName, int bufferSize)
         {
-            BeginWriteStream(new StreamWriter(fileName, false, mEncoding, bufferSize));
-
-            return this;
+            var f = new StreamWriter (fileName, false, mEncoding, bufferSize);
+            f.AutoFlush = true;
+            return BeginWriteStream (f);
         }
 
         #endregion


### PR DESCRIPTION
Enable AutoFlush FileHelperAsyncEngine write mode to avoid out-of-memory exceptions when dealing with large files.
Since FileHelpers is a helper to file operations, I guess that autoFlush should be enabled by default to avoid unpleasant surprises!

Note: Later we should set an option to allow the user to change this behavior...
