### PR TITLE
Remove always null warning

### DIFF
--- a/FileHelpers.ExcelNPOIStorage/ExcelNPOIStorage.cs
+++ b/FileHelpers.ExcelNPOIStorage/ExcelNPOIStorage.cs
@@ -433,9 +433,9 @@ namespace FileHelpers.ExcelNPOIStorage
                 res = values[0].ToString();
 
             for (int i = 1; i < values.Length; i++) {
-                res += "," + values[i] == null
+                res += "," + (values[i] == null
                     ? String.Empty
-                    : values[i].ToString();
+                    : values[i].ToString());
             }
 
             return res;


### PR DESCRIPTION
`res += "," + values[i] == null` will always be null so the "," is gone and never added to the string. 