### PR TITLE
Added Extension method for array to DT

### DIFF
--- a/FileHelpers.Tests/Tests/Common/ReadersAsDataTable.cs
+++ b/FileHelpers.Tests/Tests/Common/ReadersAsDataTable.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using System.Data;
+
 
 namespace FileHelpers.Tests.CommonTests
 {
@@ -12,26 +14,30 @@ namespace FileHelpers.Tests.CommonTests
         public void ReadFile()
         {
             var engine = new FileHelperEngine<SampleType>();
-            var dt = engine.ReadFileAsDT(FileTest.Good.Test1.Path);
+            var records = engine.ReadFile(FileTest.Good.Test1.Path);
+
+            var dt = records.ToDataTable<SampleType>();
 
             Assert.AreEqual(4, dt.Rows.Count);
             Assert.AreEqual(4, engine.TotalRecords);
             Assert.AreEqual(0, engine.ErrorManager.ErrorCount);
 
-            Assert.AreEqual(new DateTime(1314, 12, 11), (DateTime) dt.Rows[0]["Field1"]);
-            Assert.AreEqual("901", (string) dt.Rows[0]["Field2"]);
-            Assert.AreEqual(234, (int) dt.Rows[0]["Field3"]);
+            Assert.AreEqual(new DateTime(1314, 12, 11), (DateTime)dt.Rows[0]["Field1"]);
+            Assert.AreEqual("901", (string)dt.Rows[0]["Field2"]);
+            Assert.AreEqual(234, (int)dt.Rows[0]["Field3"]);
 
-            Assert.AreEqual(new DateTime(1314, 11, 10), (DateTime) dt.Rows[1]["Field1"]);
-            Assert.AreEqual("012", (string) dt.Rows[1]["Field2"]);
-            Assert.AreEqual(345, (int) dt.Rows[1]["Field3"]);
+            Assert.AreEqual(new DateTime(1314, 11, 10), (DateTime)dt.Rows[1]["Field1"]);
+            Assert.AreEqual("012", (string)dt.Rows[1]["Field2"]);
+            Assert.AreEqual(345, dt.Rows[1]["Field3"]);
         }
 
         [Test]
         public void ReadNullableTypes()
         {
             var engine = new FileHelperEngine<NullableType>();
-            var res = engine.ReadFileAsDT(FileTest.Good.NullableTypes1.Path);
+            var records = engine.ReadFile(FileTest.Good.NullableTypes1.Path);
+
+            var res = records.ToDataTable<NullableType>();
 
             Assert.AreEqual(4, res.Rows.Count);
             Assert.AreEqual(4, engine.TotalRecords);

--- a/FileHelpers/Core/FileHelperExtensions.cs
+++ b/FileHelpers/Core/FileHelperExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+
+namespace FileHelpers
+{
+    /// <summary>
+    /// Set of Extension methods to be exposed to end users 
+    /// of the FileHelper API.
+    /// </summary>
+    public static class FileHelperExtensions
+    {
+        /// <summary>
+        /// Generic extension method for arrays that returns the array records
+        /// in a DataTable.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="records">The array to transform into a DataTable</param>
+        /// <returns>The array records in a DataTable.</returns>
+        public static DataTable ToDataTable<T>(this T[] records)
+        {
+            var ri = RecordInfo.Resolve(typeof(T));
+
+            return ri.Operations.RecordsToDataTable(records);
+        }
+    }
+}
+
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This is needed per http://stackoverflow.com/questions/1522605/using-extension-methods-in-net-2-0
+    /// This is needed because of the target framework of the project being .NET 2.0. 
+    /// Remove this is the target framework is changed to a higher .NET version.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class ExtensionAttribute : Attribute { }
+}
+

--- a/FileHelpers/FileHelpers.csproj
+++ b/FileHelpers/FileHelpers.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Converters\EnumConverter.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Core\FileHelperExtensions.cs" />
     <Compile Include="Core\RecordInfo.Factory.cs" />
     <Compile Include="Core\ExtractInfo.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
Added FileHelpers namespace and updated relevant tests for ReadFileAsDT.
All tests pass. The FileHelperExtensions class was created to hold future extension methods along with mine. The API has not yet been changed. This is simply the new extension method and updated unit tests.