### PR TITLE
Implement Analyzer fix to change IComparableRecord to IComparable

### DIFF
--- a/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer.Test/FileHelpers.Analyzer.Test.csproj
+++ b/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer.Test/FileHelpers.Analyzer.Test.csproj
@@ -147,6 +147,9 @@
   <ItemGroup>
     <Folder Include="Data\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer.Test/FixIComparableRecordTest.cs
+++ b/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer.Test/FixIComparableRecordTest.cs
@@ -2,45 +2,101 @@
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using System;
+
 using TestHelper;
+
 using FileHelpersAnalyzer;
 
 namespace FileHelpersAnalyzer.Test
 {
+    using FileHelpers;
+
     [TestClass]
-    public class FixIComparableRecordTest
-        : FileHelpersCodeFixVerifier<FixIComparableRecordAnalyzer, FixIComparableRecordCodeFixProvider>
+    public class FixIComparableRecordTest :
+        FileHelpersCodeFixVerifier<FixIComparableRecordAnalyzer, FixIComparableRecordCodeFixProvider>
     {
-       
         [TestMethod]
         public void FixIComparableRecord()
         {
             var test = @"using System;
 public class Test: IComparableRecord<Test>  
 {
-  public bool IsEqualRecord(Record other)
-  {
-    return true;
-  }
+    public bool IsEqualRecord(Test other)
+    {
+        var test = 0;
+
+        // This is a test
+        for (var i = 0; i < 100; i++)
+        {
+            if (i == 53)
+                break;
+        }
+
+        return true;
+    }
 }";
 
-            var expected = new DiagnosticResult
-            {
-                Message = "Use IComparable<T>"
-            };
+            var expected = new DiagnosticResult { Message = "Use IComparable<T>" };
 
             var fixtest = @"using System;
 public class Test: IComparable<Test>  
 {
-  public int CompareTo(Record other)
-  {
-    return true;
-  }
-}";
+    public int CompareTo(Test other)
+    {
+        throw new NotImplementedException();
+        /*
+         * TODO: Implement CompareTo
+         * See: https://msdn.microsoft.com/en-us/library/43hc6wht(v=vs.110).aspx
+         *
+        var test = 0;
 
+        // This is a test
+        for (var i = 0; i < 100; i++)
+        {
+            if (i == 53)
+                break;
+        }
+
+        return true;
+         */
+    }
+}";
 
             VerifyErrorInFile(test, expected, fixtest);
         }
-   }
+
+        [TestMethod]
+        public void FixIComparableRecord2()
+        {
+            var test = @"using System;
+public class Test: IComparableRecord<Test>  
+{
+    public bool IsEqualRecord(Test other)
+    {
+        return true;
+    }
+}";
+
+            var expected = new DiagnosticResult { Message = "Use IComparable<T>" };
+
+            var fixtest = @"using System;
+public class Test: IComparable<Test>  
+{
+    public int CompareTo(Test other)
+    {
+        throw new NotImplementedException();
+        /*
+         * TODO: Implement CompareTo
+         * See: https://msdn.microsoft.com/en-us/library/43hc6wht(v=vs.110).aspx
+         *
+        return true;
+         */
+    }
+}";
+
+            VerifyErrorInFile(test, expected, fixtest);
+        }
+    }
 }

--- a/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer/FixIComparableRecord/FixIComparableRecordCodeFixProvider.cs
+++ b/FileHelpers.Analyzer/FileHelpers.Analyzer/FileHelpers.Analyzer/FixIComparableRecord/FixIComparableRecordCodeFixProvider.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -15,12 +16,12 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace FileHelpersAnalyzer
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, 
-        Name = nameof(FixIComparableRecordCodeFixProvider)), Shared]
-    public class FixIComparableRecordCodeFixProvider
-        : FileHelpersCodeFixProvider<FixIComparableRecordAnalyzer>
+    using System.Text;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FixIComparableRecordCodeFixProvider))]
+    [Shared]
+    public class FixIComparableRecordCodeFixProvider : FileHelpersCodeFixProvider<FixIComparableRecordAnalyzer>
     {
-    
         protected override async Task<Document> ApplyFix(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic)
         {
             var diagnosticSpan = diagnostic.Location.SourceSpan;
@@ -28,42 +29,102 @@ namespace FileHelpersAnalyzer
             var node = root.FindNode(diagnosticSpan) as SimpleBaseTypeSyntax;
 
             var newRoot = root;
-         
 
             var classDecl = (ClassDeclarationSyntax)node.Parent.Parent;
 
-//            var classDecl = newRoot.FindNode(classDeclOriginnode.Parent.Parent.GetLocation().SourceSpan) as ClassDeclarationSyntax;
-
-            var method = classDecl.Members.FirstOrDefault(x =>
-                x is MethodDeclarationSyntax &&
-                ((MethodDeclarationSyntax) x).Identifier.ToString() == "IsEqualRecord"
-                ) as MethodDeclarationSyntax;
-
+            var method =
+                classDecl.Members.FirstOrDefault(
+                    x =>
+                    x is MethodDeclarationSyntax
+                    && ((MethodDeclarationSyntax)x).Identifier.ToString() == "IsEqualRecord") as MethodDeclarationSyntax;
 
             if (method != null)
             {
-                newRoot = newRoot.ReplaceNode(method, 
+                var leadingComments = new[]
+                                          {
+                                              @"/*",
+                                              @" * TODO: Implement CompareTo",
+                                              @" * See: https://msdn.microsoft.com/en-us/library/43hc6wht(v=vs.110).aspx",
+                                              @" *"
+                                          };
+                var comment = new StringBuilder();
+                var leadingTrivia = method.Body.Statements.Any() && method.Body.Statements[0].HasLeadingTrivia
+                                        ? method.Body.Statements[0].GetLeadingTrivia().ToString()
+                                        : "";
+
+                foreach (var leadingComment in leadingComments)
+                {
+                    comment.AppendLine(leadingTrivia + leadingComment);
+                }
+
+                foreach (var statementSyntax in method.Body.Statements)
+                {
+                    comment.Append(
+                        statementSyntax.GetLeadingTrivia() + statementSyntax.ToString()
+                        + statementSyntax.GetTrailingTrivia());
+                }
+
+                comment.AppendLine(leadingTrivia + @" */");
+
+                var newMethodBlock = SyntaxFactory.Block(
+                    SyntaxFactory.SingletonList<StatementSyntax>(
+                        SyntaxFactory.ThrowStatement(
+                            SyntaxFactory.ObjectCreationExpression(
+                                SyntaxFactory.IdentifierName(@"NotImplementedException"))
+                                .WithNewKeyword(
+                                    SyntaxFactory.Token(
+                                        SyntaxFactory.TriviaList(),
+                                        SyntaxKind.NewKeyword,
+                                        SyntaxFactory.TriviaList(SyntaxFactory.Space)))
+                                .WithArgumentList(
+                                    SyntaxFactory.ArgumentList()
+                                        .WithOpenParenToken(SyntaxFactory.Token(SyntaxKind.OpenParenToken))
+                                        .WithCloseParenToken(SyntaxFactory.Token(SyntaxKind.CloseParenToken))))
+                            .WithThrowKeyword(
+                                SyntaxFactory.Token(
+                                    SyntaxFactory.TriviaList(SyntaxFactory.Whitespace(@" ")),
+                                    SyntaxKind.ThrowKeyword,
+                                    SyntaxFactory.TriviaList(SyntaxFactory.Space)))
+                            .WithSemicolonToken(
+                                SyntaxFactory.Token(
+                                    SyntaxFactory.TriviaList(),
+                                    SyntaxKind.SemicolonToken,
+                                    SyntaxFactory.TriviaList(
+                                        new[] { SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.Comment(comment.ToString()) })))))
+                    .WithOpenBraceToken(SyntaxFactory.Token(SyntaxKind.OpenBraceToken))
+                    .WithCloseBraceToken(
+                        SyntaxFactory.Token(
+                            SyntaxFactory.TriviaList(method.Body.GetLeadingTrivia()),
+                            SyntaxKind.CloseBraceToken,
+                            SyntaxFactory.TriviaList()))
+                    .WithLeadingTrivia(method.Body.GetLeadingTrivia())
+                    .WithTrailingTrivia(method.Body.GetTrailingTrivia());
+
+                newRoot = newRoot.ReplaceNode(
+                    method,
                     SyntaxFactory.MethodDeclaration(
-                        attributeLists: method.AttributeLists,modifiers:method.Modifiers, body:method.Body,
+                        attributeLists: method.AttributeLists,
+                        modifiers: method.Modifiers,
+                        body: newMethodBlock,
                         returnType: SyntaxFactory.ParseTypeName("int"),
                         explicitInterfaceSpecifier: method.ExplicitInterfaceSpecifier,
                         identifier: SyntaxFactory.Identifier("CompareTo"),
-                        typeParameterList:method.TypeParameterList,
+                        typeParameterList: method.TypeParameterList,
                         parameterList: method.ParameterList,
-                        constraintClauses:method.ConstraintClauses,
-                        expressionBody: method.ExpressionBody
-                        )
-                    );
+                        constraintClauses: method.ConstraintClauses,
+                        expressionBody: method.ExpressionBody));
             }
 
-            var newNode = newRoot.FindNode(diagnosticSpan) as SimpleBaseTypeSyntax; 
+            var oldNode = newRoot.FindNode(diagnosticSpan) as SimpleBaseTypeSyntax;
 
-            newRoot = newRoot.ReplaceNode(newNode,
-                SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName(node.Type.ToString().Replace("IComparableRecord<", "IComparable<"))));
-
+            newRoot = newRoot.ReplaceNode(
+                oldNode,
+                // Add trailing trivia from oldNode to maintain layout
+                SyntaxFactory.SimpleBaseType(
+                    SyntaxFactory.ParseTypeName(node.Type.ToString().Replace("IComparableRecord<", "IComparable<")))
+                    .WithTrailingTrivia(oldNode.GetTrailingTrivia()));
 
             return context.Document.WithSyntaxRoot(newRoot);
-
         }
     }
 }


### PR DESCRIPTION
The return type changes so we wrap existing code in comment-block and insert a throw of NotImplementedException. The comment-block contains a link to the doc for implementing IComparable.