### PR TITLE
Include RealCsvCommaBlankLines1.txt in .csproj

### DIFF
--- a/FileHelpers.Tests/FileHelpers.Tests.csproj
+++ b/FileHelpers.Tests/FileHelpers.Tests.csproj
@@ -600,6 +600,7 @@
     <Content Include="Data\Good\ReadAsDataTable.txt" />
     <Content Include="Data\Good\RealCsvComma1.txt" />
     <Content Include="Data\Good\RealCsvComma2.txt" />
+    <Content Include="Data\Good\RealCsvCommaBlankLines1.txt" />
     <Content Include="Data\Good\RealCsvTab1.txt" />
     <Content Include="Data\Good\RealCsvTab2.txt" />
     <Content Include="Data\Good\RealCsvVerticalBar1.txt" />


### PR DESCRIPTION
I noticed this file was missing because NCrunch copies files to the AppData folder before testing, and it only copies files referenced by the .csproj.