### PR TITLE
BigFileSorter: Auto assign block size

### DIFF
--- a/FileHelpers.Benchmarks/FileHelpers.Benchmarks.csproj
+++ b/FileHelpers.Benchmarks/FileHelpers.Benchmarks.csproj
@@ -100,6 +100,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="FixedSampleRecord.cs" />
+    <Compile Include="FixedSampleRecordSortable.cs" />
     <Compile Include="TestRecord.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/FileHelpers.Benchmarks/FixedSampleRecordSortable.cs
+++ b/FileHelpers.Benchmarks/FixedSampleRecordSortable.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace FileHelpers.Benchmarks
+{
+    /// <summary>
+    /// Sample fixed length record for testing
+    /// </summary>
+    [FixedLengthRecord()]
+    public class FixedSampleRecordSortable : IComparable<FixedSampleRecordSortable>
+    {
+        [FieldFixedLength(11)]
+        public long Cuit;
+
+        [FieldFixedLength(160)]
+        [FieldTrim(TrimMode.Both)]
+        public string Nombre;
+
+        [FieldFixedLength(6)]
+        public int Actividad;
+
+        public int CompareTo(FixedSampleRecordSortable other)
+        {
+            return this.Cuit.CompareTo(other.Cuit);
+        }
+
+
+        public void AfterRead(EngineBase engine, string line)
+        {
+            Nombre = Nombre.Replace("#", "Ñ");
+        }
+    }
+}


### PR DESCRIPTION
Modified so that if no block size is supplied a block size of 1/10th the file size is used, after some testing of various file sizes and block sizes this seemed about the correct ratio. If a block size was supplied that is used as was previously the case.

Modified the benchmark console app to allow for testing.

This is my first ever PR/contribution and usage of GitHub so please be nice if I've made any mistakes!