### PR TITLE
Added FieldKeyValue attribute which enables support for a dictionary.

### DIFF
--- a/FileHelpers.Tests/Data/Good/FieldKeyValue.txt
+++ b/FileHelpers.Tests/Data/Good/FieldKeyValue.txt
@@ -1,0 +1,3 @@
+Sales Representative                  Germany        
+Owner                                 Mexico         
+Order Administrator                   Sweden         

--- a/FileHelpers.Tests/FileHelpers.Tests.csproj
+++ b/FileHelpers.Tests/FileHelpers.Tests.csproj
@@ -164,6 +164,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Tests\Common\DynamicOptions.cs" />
+    <Compile Include="Tests\Common\FieldKeyValue.cs" />
     <Compile Include="Tests\Common\FieldNotEmpty.cs" />
     <Compile Include="Tests\Common\HeaderText.cs" />
     <Compile Include="Tests\Converters\DateFormatCulture.cs" />
@@ -617,6 +618,7 @@
     <Content Include="Data\Good\TestEmpty.txt" />
     <Content Include="Data\Good\Transform1.txt" />
     <Content Include="Data\Good\Transform2.txt" />
+    <Content Include="Data\Good\FieldKeyValue.txt" />
     <Content Include="Data\Good\Trim1.txt" />
     <Content Include="Data\Dynamic\VendorImport.xml" />
   </ItemGroup>

--- a/FileHelpers.Tests/Tests/Common/FieldKeyValue.cs
+++ b/FileHelpers.Tests/Tests/Common/FieldKeyValue.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+
+namespace FileHelpers.Tests.Tests.Common
+{
+    [TestFixture]
+    public class FieldKeyValue
+    {
+        [Test]
+        public void FieldKeyValueSimpleTest()
+        {
+            var engine = new FileHelperEngine<FieldKeyValue1>();
+            var res = TestCommon.ReadTest<FieldKeyValue1>(engine, "Good", "FieldKeyValue.txt");
+            //var res = TestCommon.ReadTest<FieldKeyValue1>(engine, "Good", @"C:\Users\larz\github\FileHelpers\FileHelpers.Tests\Data\Good\FieldKeyValue.txt");
+
+            Assert.AreEqual(res[0].ContactTitle,1);
+            Assert.AreEqual(res[1].ContactTitle, 2);
+            Assert.AreEqual(res[2].ContactTitle, 3);
+
+            Assert.AreEqual(res[0].Country, "Germany");
+            Assert.AreEqual(res[1].Country, "Mexico");
+            Assert.AreEqual(res[2].Country, "Sweden");
+        }
+
+        //The first attribute maps string -> string and the second from string->int.
+        [FixedLengthRecord]
+        private class FieldKeyValue1
+        {
+            //[FieldKeyValue("Sales Representative","SR"), FieldKeyValue("Owner", "OW"), FieldKeyValue("Order Administrator", "OA")]
+            [FieldKeyValue("Sales Representative", 1), FieldKeyValue("Owner", 2), FieldKeyValue("Order Administrator", 3)]
+            [FieldFixedLength(38)]
+            [FieldTrim(TrimMode.Both)]
+            public int ContactTitle;
+
+            [FieldFixedLength(15)]
+            [FieldTrim(TrimMode.Both)]
+            public string Country;
+        }
+    }
+}

--- a/FileHelpers/Attributes/FieldKeyValueAttribute.cs
+++ b/FileHelpers/Attributes/FieldKeyValueAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FileHelpers
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+    public sealed class FieldKeyValueAttribute : Attribute
+    {
+        public KeyValuePair<string,string> KeyValue { get; private set; }
+
+        public FieldKeyValueAttribute(object value, object key)
+        {
+            KeyValue = new KeyValuePair<string, string>(value.ToString(), key.ToString());
+        }
+    }
+}

--- a/FileHelpers/FileHelpers.csproj
+++ b/FileHelpers/FileHelpers.csproj
@@ -108,6 +108,7 @@
     </Compile>
     <Compile Include="Attributes\FieldCaptionAttribute.cs" />
     <Compile Include="Attributes\FieldHiddenAttribute.cs" />
+    <Compile Include="Attributes\FieldKeyValueAttribute.cs" />
     <Compile Include="Attributes\FieldNotEmptyAttribute.cs" />
     <Compile Include="Attributes\FieldValueDiscardedAttribute.cs" />
     <Compile Include="Attributes\FieldIgnoredAttribute.cs" />

--- a/FileHelpers/Helpers/Attributes.cs
+++ b/FileHelpers/Helpers/Attributes.cs
@@ -59,5 +59,14 @@ namespace FileHelpers
 
             action((T) attribs[0]);
         }
+
+        public static void WorkWithAll<T>(MemberInfo type, Action<T[]> action) where T : Attribute
+        {
+            var attribs = type.GetCustomAttributes(typeof(T), false);
+            if (attribs.Length == 0)
+                return;
+
+            action(Array.ConvertAll(attribs, x => (T)x));
+        }
     }
 }


### PR DESCRIPTION
## Proof of concept/suggestions - Please don't merge yet

Hello,

I've added support for a dictionary attribute

```C#
            // Map string -> string
            [FieldKeyValue("Sales Representative","SR"), FieldKeyValue("Owner", "OW"), FieldKeyValue("Order Administrator", "OA")]
            public string ContactTitle; // Results in a value of "SR", "OW", or "OA"
```
```C#
            // Map string -> int
            [FieldKeyValue("Sales Representative",1), FieldKeyValue("Owner", 1), FieldKeyValue("Order Administrator", 1)]
            public int ContactTitle; // Results in a value of 1, 2, or 3
```

Thoughts?