### PR TITLE
RecordInfo can remove multiple fields in an autoproperty class

### DIFF
--- a/FileHelpers.Tests/Tests/Common/DynamicOptions.cs
+++ b/FileHelpers.Tests/Tests/Common/DynamicOptions.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
+using System.Linq;
 using NFluent;
 using NUnit.Framework;
 
@@ -42,6 +41,22 @@ namespace FileHelpers.Tests.CommonTests
 
         }
 
+        [DelimitedRecord("|")]
+        public class CustomersVerticalBarAutoProperty
+        {
+            public string CustomerID { get; set; }
+            public string CompanyName { get; set; }
+            public string ContactName { get; set; }
+
+            public string ToRemove { get; set; }
+            
+            public string ContactTitle { get; set; }
+            public string Address { get; set; }
+            public string City { get; set; }
+            public string Country { get; set; }
+
+        }
+
         [Test]
         public void RemoveField()
         {
@@ -55,6 +70,16 @@ namespace FileHelpers.Tests.CommonTests
             Check.That(records.Length).IsEqualTo(91);
         }
 
+        [Test]
+        public void RemoveAutoPropertyMultipleFields()
+        {
+            var engine = new FileHelperEngine<CustomersVerticalBarAutoProperty>();
+
+            Check.That(engine.Options.FieldCount).IsEqualTo(8);
+            engine.Options.RemoveField("ToRemove");
+            engine.Options.RemoveField("ContactTitle");
+            Assert.That(engine.Options.Fields.Cast<FieldBase>().Select(f => f.FieldName), Has.No.Member("ContactTitle"));
+        }
 
         [Test]
         public void RemoveFieldLast()

--- a/FileHelpers/Core/RecordInfo.Factory.cs
+++ b/FileHelpers/Core/RecordInfo.Factory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FileHelpers
 {
@@ -43,7 +44,7 @@ namespace FileHelpers
 
         public void RemoveField(string fieldname)
         {
-            var index = GetFieldIndex(fieldname);
+            var index = Fields.ToList().IndexOf(Fields.Single(f => f.FieldFriendlyName == fieldname));
             Fields[index] = null;
             Fields = Array.FindAll(Fields, x => x != null);
 

--- a/FileHelpers/Options/RecordOptions.cs
+++ b/FileHelpers/Options/RecordOptions.cs
@@ -40,11 +40,6 @@ namespace FileHelpers.Options
         public void RemoveField(string fieldname)
         {
             mRecordInfo.RemoveField(fieldname);
-            //for (int i = 0; i < Fields.Count; i++)
-            //{
-            //    var field = Fields[i];
-            //    field.ParentIndex = i;
-            //}
         }
 
         /// <summary>


### PR DESCRIPTION
engine.Options.RemoveField() only works when used exactly once. Since the field indexes are not updated afterwards, subsequent calls will remove the wrong field.