### PR TITLE
Fixed nuget package for net35 framework

### DIFF
--- a/Build/NuGet/FileHelpers.nuspec
+++ b/Build/NuGet/FileHelpers.nuspec
@@ -23,8 +23,8 @@
     <files>
         <file src="..\..\Release\Lib\net20\FileHelpers.dll" target="lib\net20\FileHelpers.dll" />
         <file src="..\..\Release\Lib\net20\FileHelpers.xml" target="lib\net20\FileHelpers.xml" />
-        <file src="..\..\Release\Lib\net40\FileHelpers.dll" target="lib\net35\FileHelpers.dll" />
-        <file src="..\..\Release\Lib\net40\FileHelpers.xml" target="lib\net35\FileHelpers.xml" />
+        <file src="..\..\Release\Lib\net35\FileHelpers.dll" target="lib\net35\FileHelpers.dll" />
+        <file src="..\..\Release\Lib\net35\FileHelpers.xml" target="lib\net35\FileHelpers.xml" />
         <file src="..\..\Release\Lib\net40\FileHelpers.dll" target="lib\net40\FileHelpers.dll" />
         <file src="..\..\Release\Lib\net40\FileHelpers.xml" target="lib\net40\FileHelpers.xml" />
         <file src="..\..\Release\Lib\net45\FileHelpers.dll" target="lib\net45\FileHelpers.dll" />


### PR DESCRIPTION
Fixes #168 in stable branch

I thought this might be useful for a release 3.1.6.
What do you think Marcos?
I have not found a script which executes the nuget packaging. So this fix remains a little bit speculative.

Matthias