### PR TITLE
Support for setting NewLine string for output written by FileHelperEngine

### DIFF
--- a/FileHelpers/Engines/EngineBase.cs
+++ b/FileHelpers/Engines/EngineBase.cs
@@ -195,7 +195,7 @@ namespace FileHelpers
         /// Default is the system's newline setting (System.Environment.NewLine).
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        protected String mNewLineForWrite = Environment.NewLine;
+        private string mNewLineForWrite = Environment.NewLine;
 
         /// <summary>
         /// Newline string to be used when engine writes to file. 
@@ -205,7 +205,12 @@ namespace FileHelpers
         public string NewLineForWrite
         {
             get { return mNewLineForWrite; }
-            set { mNewLineForWrite = value; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    throw new ArgumentException("NewLine string must not be null or empty");
+                mNewLineForWrite = value;
+            }
         }
 
         #endregion

--- a/FileHelpers/Engines/EngineBase.cs
+++ b/FileHelpers/Engines/EngineBase.cs
@@ -189,6 +189,27 @@ namespace FileHelpers
 
         #endregion
 
+        #region "  NewLineForWrite  "
+        /// <summary>
+        /// Newline string to be used when engine writes to file. 
+        /// Default is the system's newline setting (System.Environment.NewLine).
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected String mNewLineForWrite = Environment.NewLine;
+
+        /// <summary>
+        /// Newline string to be used when engine writes to file. 
+        /// Default is the system's newline setting (System.Environment.NewLine).
+        /// </summary>
+        /// <value>Default is the system's newline setting.</value>
+        public string NewLineForWrite
+        {
+            get { return mNewLineForWrite; }
+            set { mNewLineForWrite = value; }
+        }
+
+        #endregion
+
         #region "  ErrorManager"
 
         /// <summary>This is a common class that manage the errors of the library.</summary>

--- a/FileHelpers/Engines/FileHelperEngine.cs
+++ b/FileHelpers/Engines/FileHelperEngine.cs
@@ -440,10 +440,10 @@ namespace FileHelpers
 
             ResetFields();
 
-            writer.NewLine = mNewLineForWrite;
+            writer.NewLine = NewLineForWrite;
 
             if (!string.IsNullOrEmpty(mHeaderText)) {
-                if (mHeaderText.EndsWith(mNewLineForWrite))
+                if (mHeaderText.EndsWith(NewLineForWrite))
                     writer.Write(mHeaderText);
                 else
                     writer.WriteLine(mHeaderText);
@@ -526,7 +526,7 @@ namespace FileHelpers
             mTotalRecords = recIndex;
 
             if (!string.IsNullOrEmpty(mFooterText)) {
-                if (mFooterText.EndsWith(mNewLineForWrite))
+                if (mFooterText.EndsWith(NewLineForWrite))
                     writer.Write(mFooterText);
                 else
                     writer.WriteLine(mFooterText);

--- a/FileHelpers/Engines/FileHelperEngine.cs
+++ b/FileHelpers/Engines/FileHelperEngine.cs
@@ -440,8 +440,10 @@ namespace FileHelpers
 
             ResetFields();
 
+            writer.NewLine = mNewLineForWrite;
+
             if (!string.IsNullOrEmpty(mHeaderText)) {
-                if (mHeaderText.EndsWith(StringHelper.NewLine))
+                if (mHeaderText.EndsWith(mNewLineForWrite))
                     writer.Write(mHeaderText);
                 else
                     writer.WriteLine(mHeaderText);
@@ -524,7 +526,7 @@ namespace FileHelpers
             mTotalRecords = recIndex;
 
             if (!string.IsNullOrEmpty(mFooterText)) {
-                if (mFooterText.EndsWith(StringHelper.NewLine))
+                if (mFooterText.EndsWith(mNewLineForWrite))
                     writer.Write(mFooterText);
                 else
                     writer.WriteLine(mFooterText);

--- a/FileHelpers/Engines/IFileHelperEngine.cs
+++ b/FileHelpers/Engines/IFileHelperEngine.cs
@@ -143,6 +143,9 @@ namespace FileHelpers
         /// <summary>The read footer in the last read operation. If any.</summary>
         string FooterText { get; set; }
 
+        /// <summary>Newline char or string to be used when engine writes records.</summary>
+        string NewLineForWrite { get; set; }
+
         /// <summary>
         /// The encoding to Read and Write the streams. Default is the system's
         /// current ANSI code page.


### PR DESCRIPTION
Hello,
I'm producing files for Unix systems on Windows, so I was looking for a way how to set a line terminator for files written by FileHelperEngine. Found a way via WriteStream(), and passing own stream with proper line terminator, but even this method is not fully compatible as it uses StringHelper.NewLine when writing file header and footer.

So I extended the IFileHelperEngine with NewLineForWrite property and updated EngineBase to use this property for write operations instead of StringHelper.NewLine.

Please include this update into product if you find this useful. Thank you for great work on this library!

Jiri