### PR TITLE
Changes related to FileHelpers Issue #225 - Need the real line number of any record

### DIFF
--- a/FileHelpers.Tests/FileHelpers.Tests.csproj
+++ b/FileHelpers.Tests/FileHelpers.Tests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Tests\Common\DynamicOptions.cs" />
     <Compile Include="Tests\Common\FieldNotEmpty.cs" />
     <Compile Include="Tests\Common\HeaderText.cs" />
+    <Compile Include="Tests\Common\RealLineNumber.cs" />
     <Compile Include="Tests\Converters\DateFormatCulture.cs" />
     <Compile Include="Tests\Dynamic\ClassBuilderTests.cs" />
     <Compile Include="Tests\Common\ConditionalRecords.cs">

--- a/FileHelpers.Tests/Tests/Common/RealLineNumber.cs
+++ b/FileHelpers.Tests/Tests/Common/RealLineNumber.cs
@@ -1,0 +1,71 @@
+using System;
+using NUnit.Framework;
+
+namespace FileHelpers.Tests.CommonTests
+{
+    [TestFixture]
+    public class RealLineNumbers
+    {
+        [Test]
+        public void RealLineNumberAppliesIgnoreEmpty()
+        {
+            var engine = new FileHelperEngine<IgnoreEmpties.IgnoreEmptyType1>();
+
+            var res = TestCommon.ReadTest<IgnoreEmpties.IgnoreEmptyType1>(engine, "Good", "IgnoreEmpty1.txt");
+
+            Assert.AreEqual(4, res.Length);
+            Assert.AreEqual(0, engine.GetRealLineNumber(0));
+            Assert.AreEqual(2, engine.GetRealLineNumber(1));
+            Assert.AreEqual(4, engine.GetRealLineNumber(2));
+            Assert.AreEqual(6, engine.GetRealLineNumber(3));
+            Assert.AreEqual(7, engine.GetRealLineNumber(4));
+            Assert.AreEqual(0, engine.GetRealLineNumber(5));
+        }
+
+        [Test]
+        public void RealLineNumberAppliesIgnoreEmpty2()
+        {
+            var engine = new FileHelperEngine<IgnoreEmpties.IgnoreEmptyType1>();
+
+            object[] res = TestCommon.ReadTest(engine, "Good", "IgnoreEmpty2.txt");
+
+            Assert.AreEqual(4, res.Length);
+            Assert.AreEqual(0, engine.GetRealLineNumber(0));
+            Assert.AreEqual(1, engine.GetRealLineNumber(1));
+            Assert.AreEqual(4, engine.GetRealLineNumber(2));
+            Assert.AreEqual(6, engine.GetRealLineNumber(3));
+            Assert.AreEqual(7, engine.GetRealLineNumber(4));
+            Assert.AreEqual(0, engine.GetRealLineNumber(5));
+        }
+
+        [Test]
+        public void RealLineNumberAppliesDiscardFirst()
+        {
+            var engine = new FileHelperEngine<DiscardType2>();
+            var res = engine.ReadFile(FileTest.Good.DiscardFirst2.Path);
+
+            Assert.AreEqual(4, res.Length);
+            Assert.AreEqual(0, engine.GetRealLineNumber(0));
+            Assert.AreEqual(3, engine.GetRealLineNumber(1));
+            Assert.AreEqual(4, engine.GetRealLineNumber(2));
+            Assert.AreEqual(5, engine.GetRealLineNumber(3));
+            Assert.AreEqual(6, engine.GetRealLineNumber(4));
+            Assert.AreEqual(0, engine.GetRealLineNumber(5));
+        }
+
+        [Test]
+        public void RealLineNumberAppliesDiscardLast()
+        {
+            var engine = new FileHelperEngine<DiscardLastType1>();
+            var res = TestCommon.ReadTest<DiscardLastType1>(engine, "Good", "DiscardLast1.txt");
+
+            Assert.AreEqual(4, res.Length);
+            Assert.AreEqual(0, engine.GetRealLineNumber(0));
+            Assert.AreEqual(1, engine.GetRealLineNumber(1));
+            Assert.AreEqual(2, engine.GetRealLineNumber(2));
+            Assert.AreEqual(3, engine.GetRealLineNumber(3));
+            Assert.AreEqual(4, engine.GetRealLineNumber(4));
+            Assert.AreEqual(0, engine.GetRealLineNumber(5));
+        }
+    }
+}

--- a/FileHelpers/Engines/EngineBase.cs
+++ b/FileHelpers/Engines/EngineBase.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Text;
 using FileHelpers.Events;
 using FileHelpers.Options;
+using System.Collections.Generic;
 
 //using Container=FileHelpers.Container;
 
@@ -78,10 +79,28 @@ namespace FileHelpers
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal int mTotalRecords;
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal Dictionary<int, int> realLineNumbers = new Dictionary<int, int>();
+
         /// <include file='FileHelperEngine.docs.xml' path='doc/LineNum/*'/>
         public int LineNumber
         {
             get { return mLineNumber; }
+        }
+
+
+        /// <summary>
+        /// Allow te retrieve the real line number of a record in the file
+        /// </summary>
+        /// <param name="recordPosition">The position of the record in the List/Datatable</param>
+        /// <returns>the line number of the record or zero</returns>
+        public int GetRealLineNumber(int recordPosition)
+        {
+            var realLine = 0;
+
+            realLineNumbers.TryGetValue(recordPosition, out realLine);
+
+            return realLine;
         }
 
         #endregion

--- a/FileHelpers/Engines/FileHelperEngine.cs
+++ b/FileHelpers/Engines/FileHelperEngine.cs
@@ -226,6 +226,7 @@ namespace FileHelpers
                 };
 
                 var values = new object[RecordInfo.FieldCount];
+                var totalObject = 0;
 
                 while (currentLine != null &&
                        currentRecord < maxRecords) {
@@ -267,6 +268,7 @@ namespace FileHelpers
 
                                 if (skip == false) {
 
+                                    realLineNumbers[++totalObject] = LineNumber;
                                     if (dt == null)
                                         result.Add(record);
                                     else


### PR DESCRIPTION
Hi,

It's related to issue #225. Event if I've never received an answer, I think it's really important!

I've added GetRealLineNumber() method in EngineBase to know the line number of any available record.
In other case, if we ignore first, last or empty lines and maybe apply a filter, we cannot find the real line in the file. It's usefull when a business check is done after the parsing and we should explain that the row contains unknown/invalid data.

I think it has no compatibillity issue with old code.
.NET Core Framework compatibility was checked and unit tests were done.

