### PR TITLE
Remove MustNotifyRead in MultiRecordEngine

### DIFF
--- a/FileHelpers/Engines/MultiRecordEngine.cs
+++ b/FileHelpers/Engines/MultiRecordEngine.cs
@@ -201,7 +201,7 @@ namespace FileHelpers
                                 OnProgress(new ProgressEventArgs(currentRecord, -1));
 
                             BeforeReadEventArgs<object> e = null;
-                            if (MustNotifyRead) // Avoid object creation
+                            if (info.NotifyRead) // Avoid object creation
                             {
                                 e = new BeforeReadEventArgs<object>(this, record, currentLine, LineNumber);
                                 skip = OnBeforeReadRecord(e);
@@ -212,7 +212,7 @@ namespace FileHelpers
                             if (skip == false) {
                                 var values = new object[info.FieldCount];
                                 if (info.Operations.StringToRecord(record, line, values)) {
-                                    if (MustNotifyRead) // Avoid object creation
+                                    if (info.NotifyRead) // Avoid object creation
                                         skip = OnAfterReadRecord(currentLine, record, e.RecordLineChanged, LineNumber);
 
                                     if (skip == false)
@@ -646,7 +646,7 @@ namespace FileHelpers
                             var values = new object[info.FieldCount];
                             mLastRecord = info.Operations.StringToRecord(line, values);
 
-                            if (MustNotifyRead)
+                            if (info.NotifyRead)
                             {
                                 OnAfterReadRecord(currentLine, mLastRecord, false, LineNumber);
                             }


### PR DESCRIPTION
The EventEngineBase.MustNotifyRead property does not work correctly in MultiRecordEngine. This is because the EngineBase.RecordInfo property is set only once based on the first record type. The easy fix is to use the local info.NotiyRead in MultiRecordEngine