### PR TITLE
ExcelNPOIStorage - Spreadsheets with blank cells

### DIFF
--- a/FileHelpers.ExcelNPOIStorage/ExcelNPOIStorage.cs
+++ b/FileHelpers.ExcelNPOIStorage/ExcelNPOIStorage.cs
@@ -98,6 +98,8 @@ namespace FileHelpers.ExcelNPOIStorage
                 else
                     mWorkbook = new HSSFWorkbook(file);
 
+                mWorkbook.MissingCellPolicy = MissingCellPolicy.CREATE_NULL_AS_BLANK;
+
                 if (String.IsNullOrEmpty(SheetName))
                     mSheet = mWorkbook.GetSheetAt(mWorkbook.ActiveSheetIndex);  
                 else {


### PR DESCRIPTION
ExtractRecords - Fix Exception index was outside the bounds of the array

The MissingCellPolicy in NPOI library is set to MissingCellPolicy.RETURN_NULL_AND_BLANK by default on both the HSSFWorkbook and XSSFWorkbook classes.

Changing the value to MissingCellPolicy.CREATE_NULL_AS_BLANK on the relevant Workbook instance resolves the issue.

FileHelpers.ExcelNPOIStorage
ExcelNPOIStorage.cs (OpenWorkbook method)
Fix on Line 101