### PR TITLE
Target NetStandard 2.0

### DIFF
--- a/FileHelpers/Csv/RecordIndexer.cs
+++ b/FileHelpers/Csv/RecordIndexer.cs
@@ -18,7 +18,7 @@ namespace FileHelpers
         internal RecordIndexer() {}
 
         [FieldQuoted(QuoteMode.OptionalForRead, MultilineMode.AllowForRead)]
-        private readonly string[] values = null;
+        private string[] values = null;
 
         /// <summary>
         /// The number of fields in the record

--- a/FileHelpers/FileHelpers.NetCore.csproj
+++ b/FileHelpers/FileHelpers.NetCore.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>FileHelpers.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -15,11 +15,11 @@
     <Copyright>Copyright 2005-2015. Marcos Meli</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <OutputPath>..\Debug\Bin\</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <OutputPath>..\Release\Bin\</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
`DynamicMethod` and `ILGenerator` are not available in `netstandard`, hence the use of expressions.

**Note:** One subtle (possibly breaking?) change is that now you cannot write to read-only members, only Emit can do this, unless I've missed something in the expression docs. Not sure if this is acceptable or not.