### PR TITLE
Removed use of obsolete LCID code usage in culture converter.

### DIFF
--- a/FileHelpers/Converters/CultureConverter.cs
+++ b/FileHelpers/Converters/CultureConverter.cs
@@ -58,7 +58,7 @@ namespace FileHelpers.Converters
 
             if (allowedDecimalSeparators.Contains(decimalSepOrCultureName))
             {
-                ci = new CultureInfo(CultureInfo.CurrentCulture.LCID);
+                ci = new CultureInfo(CultureInfo.CurrentCulture.Name);
 
                 if (decimalSepOrCultureName == ".")
                 {


### PR DESCRIPTION
Solves #412

I have removed the use of `CultureInfo.CurrentCulture.LCID` in CultureConverter and replaced it with `CultureInfo.CurrentCulture.Name` as proposed by @tarekgh in this [issue](https://github.com/dotnet/runtime/issues/60296#issuecomment-941518832).

Since this is a small change i have gone ahead and submitted a quick PR.

Unfortunatly i cannot succesfully run the net Framework tests on my machine. Since it wrongly identifies the path to the test data files. The net core test however i can run succesfully and are passing for me.
I am therefore going to create the pull request so i can use this projects CI tests.

I have also created another local commit expanding the targeted frameworks of the testing project to include both net 5 and net 6. let me know if you want this commit to be included.
Also do you want any specific new unit tests to be included?