### PR TITLE
Added the ability to have custom logic to read field values

### DIFF
--- a/FileHelpers.Tests/Tests/Common/RecordOptionsTests.cs
+++ b/FileHelpers.Tests/Tests/Common/RecordOptionsTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Linq;
+using FileHelpers.Options;
+using NUnit.Framework;
+
+namespace FileHelpers.Tests.CommonTests
+{
+    [TestFixture]
+    public class RecordOptionsTests
+    {
+        [Test]
+        public void ReadFileNotifyRecord()
+        {
+            var engine = new DelimitedFileEngine<SampleTypeCustomAttribute>();
+
+            engine.Options.ObjectToValuesHandler = x => Process(x, engine.Options);
+
+            var res = engine.WriteString(new SampleTypeCustomAttribute[] {
+                new SampleTypeCustomAttribute() { One = 100, Two = 200 },
+                new SampleTypeCustomAttribute() { One = 300, Two = 400 },
+            });
+
+            var expected = "101,-201\r\n301,-401\r\n";
+            Assert.AreEqual(expected, res);
+        }
+
+        private object[] Process(object obj, RecordOptions options) {
+            var result = new object[options.FieldCount];
+
+            for (var i = 0; i < options.FieldCount; i++) {
+                result[i] = GetValueByAttributes(obj, options.Fields[i]);
+			}
+
+            return result;
+		}
+
+        private object GetValueByAttributes(object obj, FieldBase fieldBase) {
+            var value = (int)fieldBase.FieldInfo.GetValue(obj);
+
+            if (fieldBase.FieldType == typeof(int)) {
+                var attribs = fieldBase.FieldInfo
+                    .GetCustomAttributes(false)
+                    .OfType<ICustomAttribute>();
+
+                var number = (int)value;
+                foreach (var attrib in attribs) {
+                    if (attrib is AddOneAttribute) {
+                        number++;
+					}
+                    else if (attrib is NegativeAttribute) {
+                        number = -number;
+					}
+				}
+                value = number;
+			}
+
+            return value;
+		}
+    }
+}

--- a/FileHelpers.Tests/Types/SampleTypes.cs
+++ b/FileHelpers.Tests/Types/SampleTypes.cs
@@ -79,4 +79,18 @@ namespace FileHelpers.Tests
     {
         public Guid? Field1;
     }
+
+    [DelimitedRecord(",")]
+    public class SampleTypeCustomAttribute
+    {
+        [AddOne]
+        public int One;
+        [AddOne]
+        [Negative]
+        public int Two;
+    }
+
+    public class AddOneAttribute : Attribute, ICustomAttribute { }
+    public class NegativeAttribute : Attribute, ICustomAttribute { }
+    public interface ICustomAttribute { }
 }

--- a/FileHelpers/Core/RecordOperations.cs
+++ b/FileHelpers/Core/RecordOperations.cs
@@ -166,11 +166,11 @@ namespace FileHelpers
         /// </summary>
         /// <param name="record">Object to convert</param>
         /// <returns>String representing the object</returns>
-        public string RecordToString(object record)
+        public string RecordToString(object record, ObjectToValuesDelegate objectToValuesHandler)
         {
             var sb = new StringBuilder(mRecordInfo.SizeHint);
 
-            var values = ObjectToValuesHandler(record);
+            var values = objectToValuesHandler?.Invoke(record) ?? ObjectToValuesHandler(record);
 
             for (int f = 0; f < mRecordInfo.FieldCount; f++)
                 mRecordInfo.Fields[f].AssignToString(sb, values[f]);

--- a/FileHelpers/Core/ReflectionHelper.cs
+++ b/FileHelpers/Core/ReflectionHelper.cs
@@ -25,7 +25,7 @@ namespace FileHelpers
     /// </summary>
     /// <param name="record">instance to extract from</param>
     /// <returns>Values from the instance</returns>
-    internal delegate object[] ObjectToValuesDelegate(object record);
+    public delegate object[] ObjectToValuesDelegate(object record);
 
     /// <summary>
     /// Create an object (function created based upon a type)

--- a/FileHelpers/Engines/EventEngineBase.cs
+++ b/FileHelpers/Engines/EventEngineBase.cs
@@ -208,7 +208,7 @@ namespace FileHelpers
 
                 if (skip == false)
                 {
-                    currentLine = info.Operations.RecordToString(record);
+                    currentLine = info.Operations.RecordToString(record, Options.ObjectToValuesHandler);
 
                     if (mustNotifyWriteForRecord)
                     {

--- a/FileHelpers/Engines/RecordOptions.cs
+++ b/FileHelpers/Engines/RecordOptions.cs
@@ -159,6 +159,17 @@ namespace FileHelpers.Options
             get { return mRecordConditionInfo; }
         }
 
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private ObjectToValuesDelegate mObjectToValuesHandler;
+
+		/// <summary>
+		/// Used to provide custom logic for getting the values of fields.
+		/// marker.
+		/// </summary>
+		public ObjectToValuesDelegate ObjectToValuesHandler {
+			get { return mObjectToValuesHandler; }
+			set { mObjectToValuesHandler = value; }
+		}
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly IgnoreCommentInfo mIgnoreCommentInfo;
@@ -270,7 +281,7 @@ namespace FileHelpers.Options
         /// <returns>The string representation of the current record</returns>
         public string RecordToString(object record)
         {
-            return mRecordInfo.Operations.RecordToString(record);
+            return mRecordInfo.Operations.RecordToString(record, ObjectToValuesHandler);
         }
 
         /// <summary>

--- a/FileHelpers/Fields/FieldBase.cs
+++ b/FileHelpers/Fields/FieldBase.cs
@@ -84,7 +84,7 @@ namespace FileHelpers
         /// <summary>
         /// Details about the extraction criteria
         /// </summary>
-        internal FieldInfo FieldInfo { get; private set; }
+        public FieldInfo FieldInfo { get; private set; }
 
         /// <summary>
         /// indicates whether we trim leading and/or trailing whitespace

--- a/FileHelpers/MasterDetail/MasterDetailEngine.cs
+++ b/FileHelpers/MasterDetail/MasterDetailEngine.cs
@@ -453,14 +453,14 @@ namespace FileHelpers.MasterDetail
                     if (MustNotifyProgress) // Avoid object creation
                         OnProgress(new ProgressEventArgs(recIndex + 1, max));
 
-                    currentLine = mMasterInfo.Operations.RecordToString(rec.Master);
+                    currentLine = mMasterInfo.Operations.RecordToString(rec.Master, Options.ObjectToValuesHandler);
                     writer.WriteLine(currentLine);
 
                     if (rec.Details != null)
                     {
                         for (int d = 0; d < rec.Details.Length; d++)
                         {
-                            currentLine = RecordInfo.Operations.RecordToString(rec.Details[d]);
+                            currentLine = RecordInfo.Operations.RecordToString(rec.Details[d], Options.ObjectToValuesHandler);
                             writer.WriteLine(currentLine);
                         }
                     }


### PR DESCRIPTION
We have a workflow where we need to be able to use multiple attributes that would adjust the values before serializing them. A single IConverter would not suffice in our scenario. If the ObjectToValuesDelegate and FieldInfos are exposed this would allow almost any kind of customization like this.